### PR TITLE
feat(decision): add hint about decision definition key

### DIFF
--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -16,6 +16,8 @@ import historyTimeToLive from './parts/HistoryTimeToLiveProps';
 
 // helpers ////////////////////////////////////////
 
+var DECISION_KEY_HINT = 'This maps to the decision definition key.';
+
 function createGeneralTabGroups(element, translate) {
 
   // refer to target element for external labels
@@ -27,7 +29,10 @@ function createGeneralTabGroups(element, translate) {
     entries: []
   };
 
-  idProps(generalGroup, element, translate);
+  if (is(element, 'dmn:Decision')) {
+￼	    idOptions = { description: DECISION_KEY_HINT };
+  }
+  idProps(generalGroup, element, translate, idOptions);
   nameProps(generalGroup, element, translate);
   versionTag(generalGroup, element, translate);
 

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -30,7 +30,7 @@ function createGeneralTabGroups(element, translate) {
   };
 
   if (is(element, 'dmn:Decision')) {
-￼	    idOptions = { description: DECISION_KEY_HINT };
+    idOptions = { description: DECISION_KEY_HINT };
   }
   idProps(generalGroup, element, translate, idOptions);
   nameProps(generalGroup, element, translate);

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -14,6 +14,8 @@ import versionTag from './parts/VersionTagProps';
 // history time to live
 import historyTimeToLive from './parts/HistoryTimeToLiveProps';
 
+import { is } from 'dmn-js-shared/lib/util/ModelUtil';
+
 // helpers ////////////////////////////////////////
 
 var DECISION_KEY_HINT = 'This maps to the decision definition key.';
@@ -29,6 +31,7 @@ function createGeneralTabGroups(element, translate) {
     entries: []
   };
 
+  var idOptions;
   if (is(element, 'dmn:Decision')) {
     idOptions = { description: DECISION_KEY_HINT };
   }


### PR DESCRIPTION
<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/bpmn-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->

### Proposed Changes

* Add a hint that a decision's DMN id maps to the Decision Definition Key in the Java and REST API of Camunda.

see also https://github.com/bpmn-io/bpmn-js-properties-panel/pull/294