### PR TITLE
fix(properties-panel): make sure to always paste as plain text

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -511,6 +511,16 @@ PropertiesPanel.prototype._bindListeners = function(container) {
   domDelegate.bind(container, 'input, textarea, [contenteditable]', 'input', debounce(handleChange, DEBOUNCE_DELAY));
   domDelegate.bind(container, 'input, textarea, select, [contenteditable]', 'change', handleChange);
 
+  // paste as plain text only
+  domDelegate.bind(container, '[contenteditable]', 'paste', handlePaste);
+
+  function handlePaste(event) {
+    var text = (event.clipboardData || window.clipboardData).getData('text');
+    document.execCommand('insertText', false, text);
+
+    event.preventDefault();
+  }
+
   // handle key events
   domDelegate.bind(container, 'select', 'keydown', function(e) {
 

--- a/test/spec/PropertiesPanelSpec.js
+++ b/test/spec/PropertiesPanelSpec.js
@@ -246,4 +246,11 @@ describe('PropertiesPanel', function() {
 
   });
 
+
+  describe('listeners', function() {
+
+    // Cannot be tested due to paste events not affecting document's contents per default.
+    // Cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event
+    it('should paste to [contenteditable] as plain text');
+  });
 });

--- a/test/spec/properties/PropertiesProvider.js
+++ b/test/spec/properties/PropertiesProvider.js
@@ -44,6 +44,15 @@ function createGroups(element) {
           modelProperty : 'maliciousLinkText'
         })
       ]
+    },
+    {
+      id: 'inputs',
+      entries: [
+        {
+          id: 'contenteditable',
+          html: '<div>Content editable:<div contenteditable></div></div>'
+        }
+      ]
     }
   ];
 }


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/265