### PR TITLE
fix: preserve Windows newline characters

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -519,6 +519,9 @@ PropertiesPanel.prototype._bindListeners = function(container) {
 
   function handlePaste(event) {
     var text = (event.clipboardData || window.clipboardData).getData('text');
+
+    text = normalizeEndOfLineSequences(text);
+
     document.execCommand('insertText', false, text);
 
     event.preventDefault();
@@ -1233,4 +1236,8 @@ function setContentEditableSelection(node, selection) {
   domSelection = window.getSelection();
   domSelection.removeAllRanges();
   domSelection.addRange(domRange);
+}
+
+function normalizeEndOfLineSequences(string) {
+  return string.replace(/\r\n|\r|\n/g, '\n');
 }


### PR DESCRIPTION
Fix verified through manual test since we [can't unit test it](https://github.com/bpmn-io/dmn-js-properties-panel/blob/master/test/spec/PropertiesPanelSpec.js#L252).

Related to camunda/camunda-modeler#2280

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
