### PR TITLE
 deps: bump to diagram-js@7.4.0

### DIFF
--- a/lib/adapter/decision-table/DecisionTableAdapter.js
+++ b/lib/adapter/decision-table/DecisionTableAdapter.js
@@ -48,5 +48,5 @@ export default DecisionTableAdapter;
 // helpers //////////
 
 function isImplicitRoot(element) {
-  return element.id === '__implicitroot';
+  return element && (element.isImplicit || element.id === '__implicitroot');
 }

--- a/lib/adapter/drd/DrdAdapter.js
+++ b/lib/adapter/drd/DrdAdapter.js
@@ -69,5 +69,5 @@ export default DrdAdapter;
 // helpers //////////
 
 function isImplicitRoot(element) {
-  return element.id === '__implicitroot';
+  return element && (element.isImplicit || element.id === '__implicitroot');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,9 +1925,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.2.0.tgz",
-      "integrity": "sha512-K1cJkz/e00oX+wJqaAynonteRvDi/OHP+wgJS3+lulXMUc9vdk7o5m10Vdb60Mb/Z2bsbVRyn7pJmngj/jopEQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.4.0.tgz",
+      "integrity": "sha512-leQXXWg5r1IuH+jYrE8c1VIab2L20RJMIKxIw/frsvTiqWxSuE5VrXDz+nRAgbYnrtUqzyGCtGxR0pElhUXnLw==",
       "dev": true,
       "requires": {
         "css.escape": "^1.5.1",
@@ -1937,7 +1937,7 @@
         "min-dash": "^3.5.2",
         "min-dom": "^3.1.3",
         "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.0",
+        "path-intersection": "^2.2.1",
         "tiny-svg": "^2.2.2"
       },
       "dependencies": {
@@ -1948,9 +1948,9 @@
           "dev": true
         },
         "min-dash": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.5.2.tgz",
-          "integrity": "sha512-YVbJZUtnzT5QsgJUp9H9uyJTW6NJgswFqI27RI/+MSox860uIjaGMbSQBftEzbMXiJVRG24hpoIh3SG666SHgA==",
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.0.tgz",
+          "integrity": "sha512-a0TLbmL6p4RlNGblZcLd2yjPORp+bCYRlNGvwK5OMwWaMROWh1DlRgN9W8jJm2x9gVuscvD38BEosV7cnikKnw==",
           "dev": true
         },
         "min-dom": {
@@ -6411,9 +6411,9 @@
       "dev": true
     },
     "path-intersection": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.0.tgz",
-      "integrity": "sha512-1qchRuLKhRt3qYePf9CU/74fLrBo9OTiKYNn5fxfuHJW6kTThEk04ql7w8JwOgZjNANAGp1052tWGpwZ7ItNRA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
       "dev": true
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "camunda-dmn-moddle": "^1.1.0",
     "chai": "^4.1.2",
-    "diagram-js": "^7.2.0",
+    "diagram-js": "^7.4.0",
     "dmn-js": "^10.1.0-alpha.2",
     "eslint": "^7.19.0",
     "eslint-plugin-bpmn-io": "^0.12.0",

--- a/test/spec/adapter/DecisionTableAdapterSpec.js
+++ b/test/spec/adapter/DecisionTableAdapterSpec.js
@@ -93,7 +93,8 @@ describe('DecisionTableAdapter', function() {
       // when
       eventBus.fire('root.added', {
         root: {
-          id: '__implicitroot'
+          id: '__implicitroot',
+          isImplicit: true
         }
       });
 

--- a/test/spec/adapter/DrdAdapterSpec.js
+++ b/test/spec/adapter/DrdAdapterSpec.js
@@ -125,7 +125,10 @@ describe('DrdAdapter', function() {
         // given
         var spy = sinon.spy(propertiesPanel, 'update');
 
-        canvas.setRootElement(null, true);
+        canvas.setRootElement({
+          id: '__implicitroot',
+          isImplicit: true
+        }, true);
 
         // when
         selection.select(null);

--- a/test/spec/adapter/DrdAdapterSpec.js
+++ b/test/spec/adapter/DrdAdapterSpec.js
@@ -93,7 +93,8 @@ describe('DrdAdapter', function() {
       // when
       eventBus.fire('root.added', {
         element: {
-          id: '__implicitroot'
+          id: '__implicitroot',
+          isImplicit: true
         }
       });
 


### PR DESCRIPTION
We changed the IDs for implicit root elements with diagram-js@7.4.0. This breaks the Properties panel `isImplicitRoot` check.

- check for new `isImplicit` flag
- Keep check for ID for compatibility with <7.4 releases


---

For additional context we've merged a similar behavior via https://github.com/bpmn-io/bpmn-js-properties-panel/pull/479 in the bpmn-js-properties-panel.