### PR TITLE
style: use inherit font family for all input elements

### DIFF
--- a/styles/properties.less
+++ b/styles/properties.less
@@ -32,6 +32,7 @@
   textarea,
   [contenteditable] {
     font-size: 14px;
+    font-family: inherit;
     padding: 3px 6px;
     border: 1px solid @dpp-input-border-color;
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/2458

Ensured we use the defined font family for input elements as well.

Example IBM Plex Sans (Before --> After)

![image](https://user-images.githubusercontent.com/9433996/138300168-ae5e49e2-1228-4ce8-afcc-ce8b6ae25d72.png) ![image](https://user-images.githubusercontent.com/9433996/138300199-ca34a833-af88-46d7-ac42-22b76f7d9bcf.png)


