### PR TITLE
chore: add prepare task

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:less": "lessc --include-path=node_modules styles/properties.less dist/assets/dmn-js-properties-panel.css",
     "test": "karma start",
     "pretest": "run-s build:less",
+    "prepare": "run-s build",
     "prepublishOnly": "run-s build"
   },
   "repository": {


### PR DESCRIPTION
Related to a failing build-on-demand: https://github.com/camunda/camunda-modeler/runs/3973676687?check_suite_focus=true