### PR TITLE
chore: cleanup dependencies and config

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -70,7 +70,7 @@ module.exports = function(karma) {
               options: {
                 plugins: [
                   [ '@babel/plugin-transform-react-jsx', {
-                    'importSource': 'preact',
+                    'importSource': '@bpmn-io/properties-panel/preact',
                     'runtime': 'automatic'
                   } ]
                 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -834,16 +834,6 @@
         }
       }
     },
-    "@bpmn-io/element-templates-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.3.0.tgz",
-      "integrity": "sha512-EWFHwW3OXXsBhSkyMqk4h2lUaJPMZV+C3jO5kgB90NX77dBgQyj1ii1v/7HgL2r9RfbW7G6LCTdmw2wsgceOzw==",
-      "requires": {
-        "@camunda/element-templates-json-schema": "^0.5.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^3.8.0"
-      }
-    },
     "@bpmn-io/properties-panel": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.10.1.tgz",
@@ -854,11 +844,6 @@
         "min-dash": "^3.7.0",
         "min-dom": "^3.1.3"
       }
-    },
-    "@camunda/element-templates-json-schema": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.5.0.tgz",
-      "integrity": "sha512-cFOz6SeQsNVpHlndCTQendvJrvGjFDk0rkKBgELCYjDm3XH74EonW9ujChvIcc8o9HECNQo6p7sHSAe980HWXw=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -1006,12 +991,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@polka/url": {
-      "version": "1.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
-      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
-      "dev": true
     },
     "@rollup/plugin-alias": {
       "version": "3.1.9",
@@ -2393,15 +2372,6 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
-    "camunda-bpmn-moddle": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-6.1.1.tgz",
-      "integrity": "sha512-HbYXm9lNPVnGfq4jRRtvR4YgRgw6hGwJ2wFIBghyOQ8fYsqUAPAZ4MJ1pQASZM+XpxmEyRTowc4SiHcAcFbDYw==",
-      "dev": true,
-      "requires": {
-        "min-dash": "^3.5.2"
-      }
-    },
     "camunda-dmn-moddle": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/camunda-dmn-moddle/-/camunda-dmn-moddle-1.1.0.tgz",
@@ -2617,12 +2587,6 @@
           "dev": true
         }
       }
-    },
-    "console-clear": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/console-clear/-/console-clear-1.1.1.tgz",
-      "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==",
-      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
@@ -4320,12 +4284,6 @@
         }
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
-    },
     "get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -5076,11 +5034,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5302,12 +5255,6 @@
         "webpack-merge": "^4.1.5"
       }
     },
-    "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true
-    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5357,12 +5304,6 @@
           }
         }
       }
-    },
-    "local-access": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/local-access/-/local-access-1.1.0.tgz",
-      "integrity": "sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==",
-      "dev": true
     },
     "locate-path": {
       "version": "5.0.0",
@@ -5836,18 +5777,6 @@
           "dev": true
         }
       }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true
-    },
-    "mrmime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
-      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -7118,15 +7047,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
-      "requires": {
-        "mri": "^1.1.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7177,16 +7097,11 @@
       "integrity": "sha1-gDoETcxu2rWjrmSPXwNX6JrWa5Y=",
       "dev": true
     },
-    "semiver": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semiver/-/semiver-1.1.0.tgz",
-      "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==",
-      "dev": true
-    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -7195,6 +7110,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -7202,7 +7118,8 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -7295,33 +7212,6 @@
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true
-    },
-    "sirv": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
-      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
-      "dev": true,
-      "requires": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^1.0.0"
-      }
-    },
-    "sirv-cli": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/sirv-cli/-/sirv-cli-1.0.14.tgz",
-      "integrity": "sha512-yyUTNr984ANKDloqepkYbBSqvx3buwYg2sQKPWjSU+IBia5loaoka2If8N9CMwt8AfP179cdEl7kYJ//iWJHjQ==",
-      "dev": true,
-      "requires": {
-        "console-clear": "^1.1.0",
-        "get-port": "^3.2.0",
-        "kleur": "^3.0.0",
-        "local-access": "^1.0.1",
-        "sade": "^1.6.0",
-        "semiver": "^1.0.0",
-        "sirv": "^1.0.13",
-        "tinydate": "^1.0.0"
-      }
     },
     "slash": {
       "version": "3.0.0",
@@ -7854,12 +7744,6 @@
       "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
       "dev": true
     },
-    "tinydate": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinydate/-/tinydate-1.3.0.tgz",
-      "integrity": "sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==",
-      "dev": true
-    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -7888,12 +7772,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true
-    },
-    "totalist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
-      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
     "trim-right": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^0.3.0",
     "min-dash": "^3.8.0",
-    "min-dom": "^3.1.3",
-    "semver": "^7.3.5"
+    "min-dom": "^3.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
@@ -51,13 +49,11 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@testing-library/preact": "^2.0.1",
     "babel-loader": "^8.2.2",
-    "dmn-js": "^11.1.2",
-    "camunda-bpmn-moddle": "^6.1.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^9.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.6",
-    "diagram-js": "^7.8.2",
+    "dmn-js": "^11.1.2",
     "eslint": "^7.28.0",
     "eslint-plugin-bpmn-io": "^0.12.0",
     "eslint-plugin-import": "^2.23.4",
@@ -82,12 +78,10 @@
     "rollup-plugin-react-svg": "^3.0.3",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "sirv-cli": "^1.0.12",
     "webpack": "^5.38.1"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": "0.10.x",
-    "dmn-js": "8.x",
-    "diagram-js": "7.x"
+    "dmn-js": "11.x"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,14 +23,7 @@ export default [
         file: pkg.module
       }
     ],
-    external: [
-      'min-dash',
-      'preact',
-      'preact/jsx-runtime',
-      'preact/hooks',
-      'preact/compat',
-      '@bpmn-io/properties-panel'
-    ],
+    external: externalDependencies(),
     plugins: [
       alias({
         entries: [
@@ -60,3 +53,12 @@ export default [
     ]
   }
 ];
+
+function externalDependencies() {
+  return id => {
+    return Object.keys({
+      ...pkg.dependencies,
+      ...pkg.peerDependencies
+    }).find(dep => id.startsWith(dep));
+  };
+}


### PR DESCRIPTION
This cleans up the dependencies and makes sure we don't bundle external dependencies.
Please note that we depend on `dmn-js` subpackages even though they are not declared anywhere in package.json.

```js
import { getLabel } from 'dmn-js-drd/lib/features/label-editing/LabelUtil';
import { is, getBusinessObject, isAny } from 'dmn-js-shared/lib/util/ModelUtil';
```