### PR TITLE
feat(render): add multi state + empty placeholders

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
         integration-deps:
         - "@bpmn-io/properties-panel@0.11.x"
         - "@bpmn-io/properties-panel@0.12.x"
+        - "@bpmn-io/properties-panel@0.13.x"
         - dmn-js@11.x
         - "" # as defined in package.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,9 +835,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.13.2.tgz",
-      "integrity": "sha512-S0FUjXApQ8V1tW3TkrmuxXkfiMv6WPdeKkc7DD9tzKTHHnT634GY4pafKPPknxYsLGthUiJghqWbuQahqQjz+g==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.14.0.tgz",
+      "integrity": "sha512-R5ijmBYLh/xy6wFLO5sybtCitnXKCLhr1dJFOg29Wcsz0qYHq34l1UGVmOOuz2fKWfzzwQG6xWUqi4e0Kd2wtg==",
       "dev": true,
       "requires": {
         "classnames": "^2.3.1",
@@ -847,26 +847,41 @@
       },
       "dependencies": {
         "diagram-js": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.2.1.tgz",
-          "integrity": "sha512-R9D4CtRPCXFllGE4P/UTcK3fgYG/0WQfb87Pl7frdfnAbCbjZAM2vU0qgZaBhfU0cmW2OhdDPmEtz89brrOZDA==",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.4.0.tgz",
+          "integrity": "sha512-oxfkdMPz2pnSau1GrjS/8IvLnBv/ejgsYDe0VJqCewxylLzLK7Len0oqu+gTx4uLr+tKy4hOo0wJuTOqJSBCDw==",
           "dev": true,
           "requires": {
             "css.escape": "^1.5.1",
-            "didi": "^5.2.1",
+            "didi": "^8.0.0",
             "hammerjs": "^2.0.1",
-            "inherits": "^2.0.4",
+            "inherits-browser": "0.0.1",
             "min-dash": "^3.5.2",
-            "min-dom": "^3.1.3",
+            "min-dom": "^3.2.0",
             "object-refs": "^0.3.0",
             "path-intersection": "^2.2.1",
             "tiny-svg": "^2.2.2"
+          },
+          "dependencies": {
+            "min-dom": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
+              "dev": true,
+              "requires": {
+                "component-event": "^0.1.4",
+                "domify": "^1.3.1",
+                "indexof": "0.0.1",
+                "matches-selector": "^1.2.0",
+                "min-dash": "^3.8.1"
+              }
+            }
           }
         },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+        "didi": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.0.tgz",
+          "integrity": "sha512-PwqTBaYzzfJSyxvpXPcTWF6nDdCKx2mFAU5eup1ZSb5wbaAS9a/HiKdtcAUdie/VMLHoFI50jkYZcA+bhUOugw==",
           "dev": true
         }
       }
@@ -4553,6 +4568,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "inherits-browser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw==",
+      "dev": true
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -6985,6 +7006,12 @@
           "dev": true
         }
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.14.3",
     "@babel/plugin-transform-react-jsx": "^7.14.3",
-    "@bpmn-io/properties-panel": "^0.13.2",
+    "@bpmn-io/properties-panel": "^0.14.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",
@@ -81,12 +81,13 @@
     "rollup": "^2.52.6",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-react-svg": "^3.0.3",
+    "semver-compare": "^1.0.0",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.38.1"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": "0.11.x || 0.12.x || 0.13.x",
+    "@bpmn-io/properties-panel": "0.11.x || 0.12.x || 0.13.x || 0.14.x",
     "dmn-js": "11.x || 12.x"
   }
 }

--- a/src/render/DmnPropertiesPanel.js
+++ b/src/render/DmnPropertiesPanel.js
@@ -6,6 +6,7 @@ import {
 
 import {
   find,
+  isArray,
   reduce
 } from 'min-dash';
 
@@ -16,12 +17,13 @@ import {
 } from '../context';
 
 import { PanelHeaderProvider } from './PanelHeaderProvider';
+import { PanelPlaceholderProvider } from './PanelPlaceholderProvider';
 
 /**
    * @param {Object} props
-   * @param {ModdleElement} [props.element]
+   * @param {djs.model.Base|Array<djs.model.Base>} [props.element]
    * @param {Injector} props.injector
-   * @param { (ModdleElement) => Array<PropertiesProvider> } props.getProviders
+   * @param { (djs.model.Base) => Array<PropertiesProvider> } props.getProviders
    * @param {Object} props.layoutConfig
    * @param {Object} props.descriptionConfig
    */
@@ -44,6 +46,9 @@ export default function DmnPropertiesPanel(props) {
 
   const selectedElement = state.selectedElement;
 
+  /**
+   * @param {djs.model.Base | Array<djs.model.Base>} element
+   */
   const _update = (element) => {
 
     if (!element) {
@@ -52,6 +57,7 @@ export default function DmnPropertiesPanel(props) {
 
     let newSelectedElement = element;
 
+    // handle labels
     if (newSelectedElement && newSelectedElement.type === 'label') {
       newSelectedElement = newSelectedElement.labelTarget;
     }
@@ -72,7 +78,13 @@ export default function DmnPropertiesPanel(props) {
   // (2a) selection changed
   useEffect(() => {
     const onSelectionChanged = (e) => {
-      const newElement = e.newSelection[0];
+      const { newSelection = [] } = e;
+
+      if (newSelection.length > 1) {
+        return _update(newSelection);
+      }
+
+      const newElement = newSelection[0];
 
       const rootElement = canvas.getRootElement();
 
@@ -153,6 +165,11 @@ export default function DmnPropertiesPanel(props) {
 
   const groups = useMemo(() => {
     return reduce(providers, function(groups, provider) {
+
+      // do not collect groups for multi element state
+      if (isArray(selectedElement)) {
+        return [];
+      }
       const updater = provider.getGroups(selectedElement);
 
       return updater(groups);
@@ -178,6 +195,7 @@ export default function DmnPropertiesPanel(props) {
     <PropertiesPanel
       element={ selectedElement }
       headerProvider={ PanelHeaderProvider }
+      placeholderProvider={ PanelPlaceholderProvider }
       groups={ groups }
       layoutConfig={ layoutConfig }
       layoutChanged={ onLayoutChanged }

--- a/src/render/PanelPlaceholderProvider.js
+++ b/src/render/PanelPlaceholderProvider.js
@@ -1,0 +1,20 @@
+export const PanelPlaceholderProvider = {
+
+  getEmpty: () => {
+    return {
+      text: 'Select an element to edit its properties.',
+
+      // todo(pinussilvestrus): add icon
+      icon: null
+    };
+  },
+
+  getMultiple: () => {
+    return {
+      text: 'Multiple elements are selected. Select a single element to edit its properties.',
+
+      // todo(pinussilvestrus): add icon
+      icon: null
+    };
+  },
+};

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -7,6 +7,8 @@ import {
 
 import TestContainer from 'mocha-test-container-support';
 
+import semver from 'semver';
+
 import {
   bootstrapModeler,
   inject,
@@ -89,6 +91,26 @@ export function insertCoreStyles() {
     'test.css',
     require('./test.css').default
   );
+}
+
+/**
+ * Execute test only if currently installed @bpmn-io/properties-panel is of given version.
+ *
+ * @param {string} versionRange
+ * @param {boolean} only
+ */
+export function withPropertiesPanel(versionRange, only = false) {
+  if (propertiesPanelSatisfies(versionRange)) {
+    return only ? it.only : it;
+  } else {
+    return it.skip;
+  }
+}
+
+function propertiesPanelSatisfies(versionRange) {
+  const version = require('@bpmn-io/properties-panel/package.json').version;
+
+  return semver.satisfies(version, versionRange, { includePrerelease: true });
 }
 
 export function insertDmnStyles() {

--- a/test/spec/DmnPropertiesPanel.spec.js
+++ b/test/spec/DmnPropertiesPanel.spec.js
@@ -1,4 +1,5 @@
 import {
+  act,
   render
 } from '@testing-library/preact/pure';
 
@@ -17,7 +18,8 @@ import {
 } from './mocks';
 
 import {
-  insertCoreStyles
+  insertCoreStyles,
+  withPropertiesPanel
 } from 'test/TestHelper';
 
 import DmnPropertiesPanel from 'src/render/DmnPropertiesPanel';
@@ -112,6 +114,47 @@ describe('<DmnPropertiesPanel>', function() {
   });
 
 
+  withPropertiesPanel('>=0.14')('should render - empty', async function() {
+
+    // given
+    const element = null;
+
+    const eventBus = new eventBusMock();
+
+    // when
+    const result = createDmnPropertiesPanel({ container, eventBus, element });
+
+    // then
+    expect(domQuery('.bio-properties-panel-placeholder', result.container)).to.exist;
+    expect(domQuery('.bio-properties-panel-placeholder-text', result.container)).to.exist;
+    expect(domQuery('.bio-properties-panel-placeholder-icon', result.container)).to.not.exist;
+  });
+
+
+  withPropertiesPanel('>=0.14')('should render - multiple', async function() {
+
+    // given
+    const newElements = [
+      noopElement,
+      noopElement
+    ];
+
+    const eventBus = new eventBusMock();
+
+    const result = createDmnPropertiesPanel({ container, eventBus });
+
+    // when
+    await act(() => {
+      eventBus.fire('selection.changed', { newSelection:  newElements });
+    });
+
+    // then
+    expect(domQuery('.bio-properties-panel-placeholder', result.container)).to.exist;
+    expect(domQuery('.bio-properties-panel-placeholder-text', result.container)).to.exist;
+    expect(domQuery('.bio-properties-panel-placeholder-icon', result.container)).to.not.exist;
+  });
+
+
   describe('event emitting', function() {
 
     it('should update on selection changed', function() {
@@ -131,6 +174,32 @@ describe('<DmnPropertiesPanel>', function() {
       // then
       expect(updateSpy).to.have.been.calledWith({
         element: noopElement
+      });
+    });
+
+
+    it('should update on selection changed - multiple', async function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const eventBus = new eventBusMock();
+
+      const elements = [
+        noopElement,
+        noopElement
+      ];
+
+      eventBus.on('propertiesPanel.updated', updateSpy);
+
+      createDmnPropertiesPanel({ container, eventBus });
+
+      // when
+      eventBus.fire('selection.changed', { newSelection: elements });
+
+      // then
+      expect(updateSpy).to.have.been.calledWith({
+        element: elements
       });
     });
 

--- a/test/test.css
+++ b/test/test.css
@@ -12,6 +12,7 @@ html, body, .modeler-container, .modeler-container > div {
 
 .test-content-container {
   width: 100%;
+  height: calc(100% - 24px) !important;
   display: flex;
   flex: 1;
   flex-direction: row;


### PR DESCRIPTION
Related to https://github.com/bpmn-io/properties-panel/issues/69

```sh
npx @bpmn-io/sr "bpmn-io/dmn-js-properties-panel#update-placholders"
```

![image](https://user-images.githubusercontent.com/9433996/169527079-b63cd93c-b58e-4737-acfe-45afa838f445.png)

----

What's missing here are proper icons, but I think the texts are already worth moving forward.
