### PR TITLE
Explicitly bind undo/redo shortcuts to properties container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,8 +2817,7 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
-      "dev": true
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "csso": {
       "version": "4.2.0",
@@ -2938,27 +2937,37 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.8.2.tgz",
-      "integrity": "sha512-+lzXUccgEYf9T5/1t2Y4MZyYirw47x8VEPyQ2RmDcZKO3m2iwEgyyFTOR7u6RuiVjusq7AnzgS+MVW0FhLd68A==",
-      "dev": true,
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.8.0.tgz",
+      "integrity": "sha512-isDblySC/k8dOUA1yevLPa0rdXT6Zv6+S6ZFv4CUZBk4Bgtv+3MJdnL+hVzeKPVuvlYGsEM42AyXHCW+35QJQg==",
       "requires": {
         "css.escape": "^1.5.1",
-        "didi": "^5.2.1",
+        "didi": "^8.0.0",
         "hammerjs": "^2.0.1",
-        "inherits": "^2.0.4",
+        "inherits-browser": "0.0.1",
         "min-dash": "^3.5.2",
-        "min-dom": "^3.1.3",
+        "min-dom": "^3.2.0",
         "object-refs": "^0.3.0",
         "path-intersection": "^2.2.1",
         "tiny-svg": "^2.2.2"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+        "didi": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
+          "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ=="
+        },
+        "min-dom": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+          "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.3.1",
+            "indexof": "0.0.1",
+            "matches-selector": "^1.2.0",
+            "min-dash": "^3.8.1"
+          }
         }
       }
     },
@@ -3028,6 +3037,31 @@
         "min-dom": "^3.1.3",
         "selection-ranges": "^3.0.2",
         "table-js": "^7.2.0"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
+          "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^5.2.1",
+            "hammerjs": "^2.0.1",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
       }
     },
     "dmn-js-drd": {
@@ -3044,6 +3078,33 @@
         "min-dom": "^3.1.3",
         "object-refs": "^0.3.0",
         "tiny-svg": "^2.2.1"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
+          "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^5.2.1",
+            "hammerjs": "^2.0.1",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "dmn-js-literal-expression": {
@@ -3059,6 +3120,31 @@
         "min-dash": "^3.5.2",
         "min-dom": "^3.1.3",
         "table-js": "^7.2.0"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
+          "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^5.2.1",
+            "hammerjs": "^2.0.1",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
       }
     },
     "dmn-js-shared": {
@@ -3076,6 +3162,31 @@
         "selection-ranges": "^3.0.2",
         "selection-update": "^0.1.2",
         "table-js": "^7.2.0"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
+          "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^5.2.1",
+            "hammerjs": "^2.0.1",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
       }
     },
     "dmn-moddle": {
@@ -4348,8 +4459,7 @@
     "hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "dev": true
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "has": {
       "version": "1.0.3",
@@ -4571,8 +4681,7 @@
     "inherits-browser": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
-      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw==",
-      "dev": true
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -5889,8 +5998,7 @@
     "object-refs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.3.0.tgz",
-      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ==",
-      "dev": true
+      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ=="
     },
     "object.assign": {
       "version": "4.1.2",
@@ -6400,8 +6508,7 @@
     "path-intersection": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
-      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
-      "dev": true
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7660,8 +7767,7 @@
     "tiny-svg": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
-      "dev": true
+      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "diagram-js": "^8.8.0",
     "min-dash": "^3.8.1",
     "min-dom": "^3.1.3"
   },

--- a/src/render/DmnPropertiesPanelRenderer.js
+++ b/src/render/DmnPropertiesPanelRenderer.js
@@ -1,12 +1,18 @@
 import DmnPropertiesPanel from './DmnPropertiesPanel';
 
 import {
+  isUndo,
+  isRedo
+} from 'diagram-js/lib/features/keyboard/KeyboardUtil';
+
+import {
   render
 } from '@bpmn-io/properties-panel/preact';
 
 import {
   domify,
-  query as domQuery
+  query as domQuery,
+  event as domEvent
 } from 'min-dom';
 
 const DEFAULT_PRIORITY = 1000;
@@ -31,7 +37,13 @@ export default class DmnPropertiesPanelRenderer {
     this._layoutConfig = layoutConfig;
     this._descriptionConfig = descriptionConfig;
 
-    this._container = domify('<div style="height: 100%" class="bio-properties-panel-container" input-handle-modified-keys="y,z"></div>');
+    this._container = domify(
+      '<div style="height: 100%" class="bio-properties-panel-container"></div>'
+    );
+
+    var commandStack = injector.get('commandStack', false);
+
+    commandStack && setupKeyboard(this._container, eventBus, commandStack);
 
     eventBus.on('diagram.destroy', () => {
       this.detach();
@@ -175,4 +187,43 @@ function isImplicitRoot(element) {
 
   // Backwards compatibility for diagram-js<7.4.0, see https://github.com/bpmn-io/bpmn-properties-panel/pull/102
   return element && (element.isImplicit || element.id === '__implicitroot');
+}
+
+
+/**
+ * Setup keyboard bindings (undo, redo) on the given container.
+ *
+ * @param {Element} container
+ * @param {EventBus} eventBus
+ * @param {CommandStack} commandStack
+ */
+function setupKeyboard(container, eventBus, commandStack) {
+
+  function cancel(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  function handleKeys(event) {
+
+    if (isUndo(event)) {
+      commandStack.undo();
+
+      return cancel(event);
+    }
+
+    if (isRedo(event)) {
+      commandStack.redo();
+
+      return cancel(event);
+    }
+  }
+
+  eventBus.on('keyboard.bind', function() {
+    domEvent.bind(container, 'keydown', handleKeys);
+  });
+
+  eventBus.on('keyboard.unbind', function() {
+    domEvent.unbind(container, 'keydown', handleKeys);
+  });
 }

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -1,5 +1,3 @@
-
-
 import {
   act,
   fireEvent

--- a/test/util/KeyEvents.js
+++ b/test/util/KeyEvents.js
@@ -1,0 +1,29 @@
+import {
+  assign,
+  isString,
+  omit
+} from 'min-dash';
+
+/**
+ * Create a fake key event for testing purposes.
+ *
+ * @param {String|number} key the key or keyCode/charCode
+ * @param {Object} [attrs]
+ * @param {string} [attrs.type]
+ *
+ * @return {Event}
+ */
+export function createKeyEvent(key, attrs) {
+  if (!attrs) {
+    attrs = {};
+  }
+
+  var event = document.createEvent('Events') || new document.defaultView.CustomEvent('keyEvent');
+
+  // init and mark as bubbles / cancelable
+  event.initEvent(attrs.type || 'keydown', false, true);
+
+  var keyAttrs = isString(key) ? { key: key } : { keyCode: key, which: key };
+
+  return assign(event, keyAttrs, omit(attrs, [ 'type' ]));
+}


### PR DESCRIPTION
This replicates https://github.com/bpmn-io/bpmn-js-properties-panel/pull/739 and prepares for https://github.com/bpmn-io/diagram-js/pull/662.

Built in a way that is backwards compatible though.