### PR TITLE
Httl user hint

### DIFF
--- a/src/provider/camunda/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda/properties/HistoryCleanupProps.js
@@ -52,6 +52,11 @@ function HistoryTimeToLive(props) {
     element,
     id,
     label: translate('Time to live'),
+    description: <div>
+      <a href="https://docs.camunda.org/manual/7.20/update/minor/719-to-720/#enforce-history-time-to-live" target="_blank" rel="noopener" title={ translate('Time to live documentation') }>
+        { translate('Learn more about time to live') }
+      </a>
+    </div>,
     getValue,
     setValue,
     debounce

--- a/src/provider/camunda/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda/properties/HistoryCleanupProps.js
@@ -52,10 +52,11 @@ function HistoryTimeToLive(props) {
     element,
     id,
     label: translate('Time to live'),
-    description: <div>
-      <a href="https://docs.camunda.org/manual/7.20/update/minor/719-to-720/#enforce-history-time-to-live" target="_blank" rel="noopener" title={ translate('Time to live documentation') }>
-        { translate('Learn more about time to live') }
-      </a>
+    tooltip: <div>
+      <p>
+        { translate('Number of days before this resource is being cleaned up. If specified, takes precedence over the engine configuration.') }{' '}
+        <a href="https://docs.camunda.org/manual/7.20/update/minor/719-to-720/#enforce-history-time-to-live" target="_blank" rel="noopener">{ translate('Learn more') }</a>
+      </p>
     </div>,
     getValue,
     setValue,

--- a/src/provider/camunda/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda/properties/HistoryCleanupProps.js
@@ -55,7 +55,7 @@ function HistoryTimeToLive(props) {
     tooltip: <div>
       <p>
         { translate('Number of days before this resource is being cleaned up. If specified, takes precedence over the engine configuration.') }{' '}
-        <a href="https://docs.camunda.org/manual/7.20/update/minor/719-to-720/#enforce-history-time-to-live" target="_blank" rel="noopener">{ translate('Learn more') }</a>
+        <a href="https://docs.camunda.org/manual/latest/user-guide/process-engine/history/" target="_blank" rel="noopener">{ translate('Learn more') }</a>
       </p>
     </div>,
     getValue,


### PR DESCRIPTION
Builds on top of https://github.com/bpmn-io/dmn-js-properties-panel/pull/81 to add a hint for HTTL + link to additional documentation:

![capture 3GXYgy_optimized](https://github.com/bpmn-io/dmn-js-properties-panel/assets/58601/2e03f8e2-a8a4-4dd4-b8c4-f55eb48e2a87)

Related to https://github.com/camunda/camunda-modeler/issues/4062



