### PR TITLE
fix: make name field a text area

### DIFF
--- a/src/provider/dmn/properties/NameProps.js
+++ b/src/provider/dmn/properties/NameProps.js
@@ -1,7 +1,4 @@
-import {
-  TextFieldEntry,
-  isTextFieldEntryEdited
-} from '@bpmn-io/properties-panel';
+import { TextAreaEntry, isTextAreaEntryEdited } from '@bpmn-io/properties-panel';
 
 import { getBusinessObject } from 'dmn-js-shared/lib/util/ModelUtil';
 
@@ -35,7 +32,7 @@ export function NameProps(props) {
       id: 'name',
       component: Name,
       element,
-      isEdited: isTextFieldEntryEdited
+      isEdited: isTextAreaEntryEdited
     }
   ];
 }
@@ -81,5 +78,5 @@ function Name(props) {
     };
   }
 
-  return TextFieldEntry(options);
+  return TextAreaEntry(options);
 }

--- a/src/provider/dmn/properties/NameProps.js
+++ b/src/provider/dmn/properties/NameProps.js
@@ -60,7 +60,8 @@ function Name(props) {
       modeling.updateProperties(element, {
         name: value
       });
-    }
+    },
+    autoResize: true
   };
 
   // (2) text annotation

--- a/test/spec/provider/dmn/NameProps.spec.js
+++ b/test/spec/provider/dmn/NameProps.spec.js
@@ -57,7 +57,7 @@ describe('provider/dmn - NameProps', function() {
     });
 
     // when
-    const idInput = domQuery('input[name=name]', container);
+    const idInput = domQuery('textarea[name=name]', container);
 
     // then
     expect(idInput.value).to.eql(getBusinessObject(shape).get('name'));
@@ -74,7 +74,7 @@ describe('provider/dmn - NameProps', function() {
     });
 
     // when
-    const nameInput = domQuery('input[name=name]', container);
+    const nameInput = domQuery('textarea[name=name]', container);
     changeInput(nameInput, 'newValue');
 
     // then
@@ -92,7 +92,7 @@ describe('provider/dmn - NameProps', function() {
       await act(() => {
         selection.select(shape);
       });
-      const nameInput = domQuery('input[name=name]', container);
+      const nameInput = domQuery('textarea[name=name]', container);
       changeInput(nameInput, 'newValue');
 
       // when


### PR DESCRIPTION
Closes #94

Make "Name" field a text area instead of an input to support multiple lines of text.

![image](https://github.com/bpmn-io/dmn-js-properties-panel/assets/24656920/be94918e-6cb0-45f4-8042-d26e1927f8ef)


