### PR TITLE
chore: remove legacy check

### DIFF
--- a/src/render/DmnPropertiesPanel.js
+++ b/src/render/DmnPropertiesPanel.js
@@ -220,9 +220,7 @@ export default function DmnPropertiesPanel(props) {
 // helpers //////////////////////////
 
 function isImplicitRoot(element) {
-
-  // Backwards compatibility for diagram-js<7.4.0, see https://github.com/bpmn-io/bpmn-properties-panel/pull/102
-  return element && (element.isImplicit || element.id === '__implicitroot');
+  return element && element.isImplicit;
 }
 
 function findElement(elements, element) {

--- a/src/render/DmnPropertiesPanelRenderer.js
+++ b/src/render/DmnPropertiesPanelRenderer.js
@@ -192,9 +192,7 @@ DmnPropertiesPanelRenderer.$inject = [ 'config.propertiesPanel', 'injector', 'ev
 // helpers ///////////////////////
 
 function isImplicitRoot(element) {
-
-  // Backwards compatibility for diagram-js<7.4.0, see https://github.com/bpmn-io/bpmn-properties-panel/pull/102
-  return element && (element.isImplicit || element.id === '__implicitroot');
+  return element && element.isImplicit;
 }
 
 

--- a/test/spec/DmnPropertiesPanel.spec.js
+++ b/test/spec/DmnPropertiesPanel.spec.js
@@ -258,7 +258,6 @@ describe('<DmnPropertiesPanel>', function() {
       // when
       eventBus.fire('root.added', {
         element: {
-          id: '__implicitroot',
           isImplicit: true
         }
       });
@@ -282,7 +281,6 @@ describe('<DmnPropertiesPanel>', function() {
       eventBus.fire('selection.changed', {
         oldSelectiom: {},
         newSelection: [ {
-          id: '__implicitroot',
           isImplicit: true
         } ]
       });


### PR DESCRIPTION
We don't need it since we require more
recent diagram-js version.

Related to https://github.com/bpmn-io/dmn-js-properties-panel/pull/104/commits/75c4418aa1a499f99b2548b0b0a20f0abe4ac8f3

### Proposed Changes

* This removes the implicit root ID check which was required prior to diagram-js@7.4.0