### PR TITLE
Fix test suite to properly handle async specs

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -81,6 +81,10 @@ export function clickInput(input) {
   fireEvent.click(input);
 }
 
+export function mouseEnter(element) {
+  fireEvent.mouseEnter(element);
+}
+
 export function insertCoreStyles() {
   insertCSS(
     'properties-panel.css',

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -128,15 +128,7 @@ export function inject(fn) {
       throw new Error('no active view found');
     }
 
-    view.invoke(fn);
-  };
-}
-
-export function injectAsync(doneFn) {
-  return function(done) {
-    let testFn = doneFn(done);
-
-    inject(testFn)();
+    return view.invoke(fn);
   };
 }
 

--- a/test/spec/DmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/DmnPropertiesPanelRenderer.spec.js
@@ -94,7 +94,7 @@ describe('<DmnPropertiesPanelRenderer>', function() {
 
     setDmnJS(modeler);
 
-    modeler.on('viewer.created', ({ viewer }) => {
+    singleStart && modeler.on('viewer.created', ({ viewer }) => {
       viewer.on('commandStack.changed', function() {
         modeler.saveXML({ format: true }).then(function(result) {
           console.log(result.xml);

--- a/test/spec/DmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/DmnPropertiesPanelRenderer.spec.js
@@ -421,9 +421,10 @@ describe('<DmnPropertiesPanelRenderer>', function() {
   describe('header name', function() {
 
     beforeEach(async function() {
-      await createModeler(diagramXml);
+      await act(async () => {
+        await createModeler(diagramXml);
+      });
     });
-
 
     it('should keep state during detach and attach', inject(async function(elementRegistry, selection, propertiesPanel) {
 

--- a/test/spec/provider/camunda/IdProps.spec.js
+++ b/test/spec/provider/camunda/IdProps.spec.js
@@ -116,10 +116,10 @@ describe('provider/dmn - IdProps', function() {
     it('should set invalid', inject(async function(elementRegistry, selection) {
 
       // given
-      const task = elementRegistry.get('Task_1');
+      const shape = elementRegistry.get('Decision_1');
 
       await act(() => {
-        selection.select(task);
+        selection.select(shape);
       });
 
       // when
@@ -129,7 +129,7 @@ describe('provider/dmn - IdProps', function() {
       });
 
       // then
-      const error = domQuery('.bio-properties-panel-input-error', container);
+      const error = domQuery('.bio-properties-panel-error', container);
       expect(error).to.exist;
     }));
 
@@ -143,8 +143,11 @@ describe('provider/dmn - IdProps', function() {
         selection.select(shape);
       });
 
-      // when
+      // expect
       const idInput = domQuery('input[name=id]', container);
+      expect(idInput.value).to.exist;
+
+      // when
       changeInput(idInput, '');
 
       // then

--- a/test/spec/provider/dmn/DocumentationProps.dmn
+++ b/test/spec/provider/dmn/DocumentationProps.dmn
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="definitions_dish" name="Dish" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
   <decision id="Decision" name="Decision">
+    <description>Decision description</description>
+    <question>Decision question</question>
+    <allowedAnswers>Decision allowed answers</allowedAnswers>
     <informationRequirement id="InformationRequirement">
+      <description>Information requirement description</description>
       <requiredInput href="#Input" />
     </informationRequirement>
   </decision>
-  <inputData id="Input" name="Input" />
+  <inputData id="Input" name="Input">
+    <description>Input description</description>
+  </inputData>
   <textAnnotation id="TextAnnotation">
+    <description>Text annotation description</description>
     <text>TextAnnotation</text>
   </textAnnotation>
   <association id="Association">
-    <description>Description</description>
+    <description>Association description</description>
     <sourceRef href="#TextAnnotation" />
     <targetRef href="#Decision" />
   </association>

--- a/test/spec/provider/dmn/DocumentationProps.spec.js
+++ b/test/spec/provider/dmn/DocumentationProps.spec.js
@@ -69,7 +69,7 @@ describe('provider/dmn - DocumentationProps', function() {
         });
 
         // when
-        const input = domQuery(`input[name=${property}]`, container);
+        const input = domQuery(`textarea[name=${property}]`, container);
 
         // then
         expect(input.value).to.eql(getBusinessObject(element).get(property));
@@ -86,7 +86,7 @@ describe('provider/dmn - DocumentationProps', function() {
         });
 
         // when
-        const nameInput = domQuery(`input[name=${property}]`, container);
+        const nameInput = domQuery(`textarea[name=${property}]`, container);
         changeInput(nameInput, 'newValue');
 
         // then
@@ -104,7 +104,7 @@ describe('provider/dmn - DocumentationProps', function() {
           await act(() => {
             selection.select(element);
           });
-          const nameInput = domQuery(`input[name=${property}]`, container);
+          const nameInput = domQuery(`textarea[name=${property}]`, container);
           changeInput(nameInput, 'newValue');
 
           // when
@@ -135,7 +135,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const input = domQuery(`input[name=${property}]`, container);
+      const input = domQuery(`textarea[name=${property}]`, container);
 
       // then
       expect(input.value).to.eql(getBusinessObject(element).get(property));
@@ -152,7 +152,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const input = domQuery(`input[name=${property}]`, container);
+      const input = domQuery(`textarea[name=${property}]`, container);
 
       // then
       expect(input).to.not.exist;
@@ -169,7 +169,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const nameInput = domQuery(`input[name=${property}]`, container);
+      const nameInput = domQuery(`textarea[name=${property}]`, container);
       changeInput(nameInput, 'newValue');
 
       // then
@@ -187,7 +187,7 @@ describe('provider/dmn - DocumentationProps', function() {
         await act(() => {
           selection.select(element);
         });
-        const nameInput = domQuery(`input[name=${property}]`, container);
+        const nameInput = domQuery(`textarea[name=${property}]`, container);
         changeInput(nameInput, 'newValue');
 
         // when
@@ -217,7 +217,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const input = domQuery(`input[name=${property}]`, container);
+      const input = domQuery(`textarea[name=${property}]`, container);
 
       // then
       expect(input.value).to.eql(getBusinessObject(element).get(property));
@@ -234,7 +234,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const input = domQuery(`input[name=${property}]`, container);
+      const input = domQuery(`textarea[name=${property}]`, container);
 
       // then
       expect(input).to.not.exist;
@@ -251,7 +251,7 @@ describe('provider/dmn - DocumentationProps', function() {
       });
 
       // when
-      const nameInput = domQuery(`input[name=${property}]`, container);
+      const nameInput = domQuery(`textarea[name=${property}]`, container);
       changeInput(nameInput, 'newValue');
 
       // then
@@ -269,7 +269,7 @@ describe('provider/dmn - DocumentationProps', function() {
         await act(() => {
           selection.select(element);
         });
-        const nameInput = domQuery(`input[name=${property}]`, container);
+        const nameInput = domQuery(`textarea[name=${property}]`, container);
         changeInput(nameInput, 'newValue');
 
         // when

--- a/test/spec/provider/dmn/IdProps.spec.js
+++ b/test/spec/provider/dmn/IdProps.spec.js
@@ -108,20 +108,23 @@ describe('provider/dmn - IdProps', function() {
     it('should set invalid', inject(async function(elementRegistry, selection) {
 
       // given
-      const task = elementRegistry.get('Task_1');
+      const shape = elementRegistry.get('Decision_1');
 
       await act(() => {
-        selection.select(task);
+        selection.select(shape);
       });
 
-      // when
+      // expect
       const idInput = domQuery('input[name=id]', container);
+      expect(idInput.value).to.exist;
+
+      // when
       await act(() => {
         changeInput(idInput, '');
       });
 
       // then
-      const error = domQuery('.bio-properties-panel-input-error', container);
+      const error = domQuery('.bio-properties-panel-error', container);
       expect(error).to.exist;
     }));
 


### PR DESCRIPTION
As a matter of fact the test suite to date does not correctly handle async specs like this, a prominent (and used) pattern:

```javascript
describe('some spec', function() {

  it('test asynch', inject(async function(...) {
    throw new Error('HAHA, this will not be reported as a test failure');
  }));
  
});
```

I fixed this via https://github.com/bpmn-io/dmn-js-properties-panel/commit/c9ee6435e3cfe2d262ab0b707ce9054a1034e0ec.

Of course this covers up a bunch (24 / 130) broken tests. One test (verifying version tag tooltip) was completely broken, [used a non-existing utility](https://github.com/bpmn-io/dmn-js-properties-panel/commit/4e2155a7cb3d65d2748f2e497900ebcf062993df), and was [structured so it would never work](https://github.com/bpmn-io/dmn-js-properties-panel/commit/e41a5920300f276765eb06b6bbd3a933659f07c0). The test is now properly architected, and works, modeling a user flow:

![capture GKfmi2_optimized](https://github.com/user-attachments/assets/a0455753-723a-482a-a602-1b81db764fe8)

I did not touch the other 24 failing tests, but I suggest we handle them ("make them work") in similar ways.