### PR TITLE
fix: add variable name assignment on variable creation

### DIFF
--- a/src/provider/dmn/properties/TypeRefProps.js
+++ b/src/provider/dmn/properties/TypeRefProps.js
@@ -57,7 +57,11 @@ function TypeRef(props) {
   const setValue = (value) => {
     const variable = businessObject.get('variable');
     if (!variable) {
-      modeling.updateProperties(element, { variable: drdFactory.create('dmn:InformationItem', { typeRef: value }) });
+      modeling.updateProperties(element, {
+        variable: drdFactory.create('dmn:InformationItem', {
+          name: businessObject.get('name') || '',
+          typeRef: value }),
+      });
       return;
     }
 

--- a/test/spec/provider/dmn/TypeRefProps.dmn
+++ b/test/spec/provider/dmn/TypeRefProps.dmn
@@ -24,6 +24,7 @@
   <inputData id="NoType" name="No type">
     <variable name="No type" />
   </inputData>
+  <decision id="NoNameDecision" />
   <knowledgeSource id="KnowledgeSource" name="Knowledge Source" />
   <businessKnowledgeModel id="BusinessKnowledgeModel" name="BKM" />
   <textAnnotation id="TextAnnotation">
@@ -77,6 +78,9 @@
       </dmndi:DMNEdge>
       <dmndi:DMNShape id="DMNShape_0x9hnzv" dmnElementRef="NoType">
         <dc:Bounds height="45" width="125" x="648" y="369" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_noname" dmnElementRef="NoNameDecision">
+        <dc:Bounds height="80" width="180" x="160" y="80" />
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="DMNEdge_13torhu" dmnElementRef="InformationRequirement_0j52lfm">
         <di:waypoint x="711" y="369" />

--- a/test/spec/provider/dmn/TypeRefProps.spec.js
+++ b/test/spec/provider/dmn/TypeRefProps.spec.js
@@ -277,7 +277,31 @@ describe('provider/dmn - TypeRefProps', function() {
       expect(variable).to.exist;
       expect(is(variable, 'dmn:InformationItem'), 'variable should be an InformationItem').to.be.true;
       expect(variable.get('typeRef')).to.eql('string');
+      expect(variable.get('name')).to.eql('No variable');
     });
+
+    it('should add variable with empty name if element has no name', inject(async function(elementRegistry, selection) {
+
+      // given
+      const decision = elementRegistry.get('NoNameDecision');
+
+      await act(() => {
+        selection.select(decision);
+      });
+
+      // when
+      const typeDropdown = domQuery('select[name=typeRef]', container);
+      changeInput(typeDropdown, 'string');
+
+      // then
+      const businessObject = getBusinessObject(decision);
+      const variable = businessObject.get('variable');
+
+      expect(variable).to.exist;
+      expect(is(variable, 'dmn:InformationItem'), 'variable should be an InformationItem').to.be.true;
+      expect(variable.get('typeRef')).to.eql('string');
+      expect(variable.get('name')).to.eql('');
+    }));
 
 
     it('should undo', inject(async function(commandStack) {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5945

### Proposed Changes

Add variable name assignment on variable creation


https://github.com/user-attachments/assets/7ca6f6ff-bc41-4fa7-918b-20562188ae96



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
